### PR TITLE
Agrega comunidad WordPress Medellín

### DIFF
--- a/meetups.html
+++ b/meetups.html
@@ -70,6 +70,7 @@
                 <li><a href="https://www.meetup.com/node_co/" target="_blank">Node Colombia</a></li>
                 <li><a href="https://www.meetup.com/es/GDG-Medellin" target="_blank">GDG Medellin (Google Developer Group)</a></li>
                 <li><a href=“http://www.meetup.com/Python-Ladies-Medellin/” target=“_blank”>Pyladies Medellín</a></li>
+                <li><a href="https://www.meetup.com/es-ES/WordPressMedellin" target="_blank">WordPress Medellin</a></li>
             </ul>
         </section>
         <section class="small-12">

--- a/meetups.html
+++ b/meetups.html
@@ -70,7 +70,7 @@
                 <li><a href="https://www.meetup.com/node_co/" target="_blank">Node Colombia</a></li>
                 <li><a href="https://www.meetup.com/es/GDG-Medellin" target="_blank">GDG Medellin (Google Developer Group)</a></li>
                 <li><a href=“http://www.meetup.com/Python-Ladies-Medellin/” target=“_blank”>Pyladies Medellín</a></li>
-                <li><a href="https://www.meetup.com/es-ES/WordPressMedellin" target="_blank">WordPress Medellin</a></li>
+                <li><a href="https://wpmedellin.com" data-meetup-id="WordPressMedellin" target="_blank">WordPress Medellín</a></li>
             </ul>
         </section>
         <section class="small-12">


### PR DESCRIPTION
Por alguna razón #37 no llegó a `master` si no que existe como un [branch adicional](https://github.com/colombia-dev/colombia-dev.github.io/tree/agregar-link-comuniades) en este repo, por lo que la comunidad todavía no aparece en el sitio web.

Esta es una nueva versión de https://github.com/colombia-dev/colombia-dev.github.io/pull/37 que usa `master` como base branch y además agrega la URL del sitio web de la comunidad y el atributo `data-meetup-id`.